### PR TITLE
unit comparison with arithmetic units

### DIFF
--- a/R/rbind-cbind.r
+++ b/R/rbind-cbind.r
@@ -15,29 +15,25 @@ rbind.gtable <- function(..., size = "max") {
   Reduce(function(x, y) rbind_gtable(x, y, size = size), list(...))
 }
 
-rbind_gtable <- function(x, y, size = "max") {
-  stopifnot(ncol(x) == ncol(y))
-  if (nrow(x) == 0) return(y)
-  if (nrow(y) == 0) return(x)
-  
-  y$layout$t <- y$layout$t + nrow(x)
-  y$layout$b <- y$layout$b + nrow(x)
-  x$layout <- rbind(x$layout, y$layout)
 
-  x$heights <- insert.unit(x$heights, y$heights)
-  x$rownames <- c(x$rownames, y$rownames)
-
-  size <- match.arg(size, c("first", "last", "max", "min"))
-  x$widths <- switch(size,
-    first = x$widths,
-    last = y$widths,
-    min = compare.unit(x$widths, y$widths, pmin),
-    max = compare.unit(x$widths, y$widths, pmax)
-  )
-
-  x$grobs <- append(x$grobs, y$grobs)
-
-  x
+rbind_gtable <- function (x, y, size = "max") 
+{
+    stopifnot(ncol(x) == ncol(y))
+    if (nrow(x) == 0) 
+        return(y)
+    if (nrow(y) == 0) 
+        return(x)
+    y$layout$t <- y$layout$t + nrow(x)
+    y$layout$b <- y$layout$b + nrow(x)
+    x$layout <- rbind(x$layout, y$layout)
+    x$heights <- insert.unit(x$heights, y$heights)
+    x$rownames <- c(x$rownames, y$rownames)
+    size <- match.arg(size, c("first", "last", "max", "min"))
+    x$widths <- switch(size, first = x$widths, last = y$widths, 
+        min = unit.pmin(x$widths, y$widths), max = unit.pmax(x$widths, 
+            y$widths))
+    x$grobs <- append(x$grobs, y$grobs)
+    x
 }
 
 #' @rdname bind


### PR DESCRIPTION
`compare.unit` fails with arithmetic units:

``` r
s1 <- max(grobWidth(textGrob("a")), grobWidth(textGrob("1")))
s2 <- max(grobWidth(textGrob("a")), grobWidth(textGrob("2")))
gtable:::compare.unit(s1, s2, pmin)
unit.pmin(s1, s2)
```

Better use `unit.pmax` and `unit.pmin` I think.
