### PR TITLE
Finer control of gtable_show_layout

### DIFF
--- a/R/grid.r
+++ b/R/grid.r
@@ -2,10 +2,11 @@
 #'
 #' @export
 #' @param x a gtable object
-gtable_show_layout <- function(x) {
+#' @param ... additional parameters passed on to grid::grid.show.layout().
+gtable_show_layout <- function(x, ...) {
   stopifnot(is.gtable(x))
 
-  grid.show.layout(gtable_layout(x))
+  grid.show.layout(gtable_layout(x), ...)
 }
 
 gtable_layout <- function(x) {

--- a/man/gtable_show_layout.Rd
+++ b/man/gtable_show_layout.Rd
@@ -4,12 +4,13 @@
 \alias{gtable_show_layout}
 \title{Visualise the layout of a gtable.}
 \usage{
-gtable_show_layout(x)
+gtable_show_layout(x, ...)
 }
 \arguments{
 \item{x}{a gtable object}
+
+\item{...}{additional parameters passed on to grid::grid.show.layout().}
 }
 \description{
 Visualise the layout of a gtable.
 }
-


### PR DESCRIPTION
In the current implementation, `gtable_show_layout()` uses default parameter settings of `grid::grid.show.layout()`. One can call `grid.show.layout()` directly, but since `gtable_layout()` is not exported, the user would first have to construct the layout object "by hand". The proposed change offers a small convenience in being able to adjust display parameters (such as `vp.ex`) directly through `gtable_show_layout()`.