### PR TITLE
gtable_trim now works with empty tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 * New logo
 
+* gtable_trim now works with empty gtables
+
 # gtable 0.2.0
 
 * Switch from `preDrawDetails()` and `postDrawDetails()` methods to

--- a/R/trim.r
+++ b/R/trim.r
@@ -30,6 +30,10 @@
 #' plot(gtable_trim(row))
 gtable_trim <- function(x) {
   if (!is.gtable(x)) stop("x must be a gtable", call. = FALSE)
+  if (length(x) == 0) {
+    return(gtable(respect = x$respect, name = x$name, vp = x$vp))
+  }
+
   layout <- unclass(x$layout)
 
   w <- range(layout$l, layout$r)

--- a/tests/testthat/test-trim.R
+++ b/tests/testthat/test-trim.R
@@ -1,0 +1,12 @@
+context("trim")
+
+gt_empty <- gtable(
+  widths = unit(rep(1, 4), 'null'),
+  heights = unit(rep(1, 4), 'null')
+)
+gt <- gtable_add_grob(gt_empty, rectGrob(), 1, 1)
+
+test_that("trimming works", {
+  expect_equal(dim(gtable_trim(gt)), c(1, 1))
+  expect_equal(dim(gtable_trim(gt_empty)), c(0, 0))
+})


### PR DESCRIPTION
Fix #37 

Before, calling `gtable_trim()` on an empty gtable object would result in an incomprehensible error message: 

```r
Error in seq.int(w[1], w[2]) : 'from' must be a finite number
In addition: Warning messages:
1: In min(x) : no non-missing arguments to min; returning Inf
2: In max(x) : no non-missing arguments to max; returning -Inf
3: In min(x) : no non-missing arguments to min; returning Inf
4: In max(x) : no non-missing arguments to max; returning -Inf
```

This had further repercussions for `gtable_filter()` that called `gtable_trim()` by default and might return an empty gtable