### PR TITLE
Specify rlang version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     glue,
     grid,
     lifecycle,
-    rlang
+    rlang (>= 1.1.0)
 Suggests:
     covr,
     ggplot2,


### PR DESCRIPTION
This PR is due to the issue described in https://github.com/tidyverse/ggplot2/issues/5235.
The PR increments the rlang version such that the checks can find the relevant rlang code.