### PR TITLE
Avoid partial match of `just` to `justification`

### DIFF
--- a/R/gtable.R
+++ b/R/gtable.R
@@ -117,7 +117,7 @@ gtable <- function(widths = list(), heights = list(), respect = FALSE,
       name = name,
       x = vp$x, y = vp$y,
       width = vp$width, height = vp$height,
-      just = vp$just, gp = vp$gp, xscale = vp$xscale,
+      just = vp$justification, gp = vp$gp, xscale = vp$xscale,
       yscale = vp$yscale, angle = vp$angle, clip = vp$clip
     )
   }


### PR DESCRIPTION
This PR aims to fix https://github.com/tidyverse/ggplot2/issues/5654.

Briefly, when a viewport is provided to `gtable()`, it is reconstituted but the `justification` field is extracted via `$just`.
This PR changes this to `$justification`, avoiding the partial match.

The reprex from https://github.com/tidyverse/ggplot2/issues/5654#issuecomment-1902198119 now does not throw an error:

``` r
devtools::load_all("~/packages/gtable/")
#> ℹ Loading gtable
library(grid)
options(warnPartialMatchDollar = TRUE)
options(warn = 2) 

gtable(
  widths = unit(1, "cm"),
  heights = unit(1, "cm"),
  vp = viewport()
)
#> TableGrob (1 x 1) "layout": 0 grobs
```

<sup>Created on 2024-01-23 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
